### PR TITLE
Fix results section visibility on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -26,8 +26,16 @@ body{
 .decor-2{width:420px; height:420px; bottom:-140px; left:-90px;}
 
 .container{max-width:1160px; margin:0 auto; padding:0 20px}
-.section{padding:72px 0; opacity:0; transform:translateY(14px); transition:opacity .6s ease, transform .6s ease}
-.section.in{opacity:1; transform:none}
+.section{padding:72px 0;}
+
+@media (prefers-reduced-motion: no-preference){
+  .section{opacity:0; transform:translateY(14px); transition:opacity .6s ease, transform .6s ease}
+  .section.in{opacity:1; transform:none}
+}
+
+@media (prefers-reduced-motion: reduce){
+  .section{opacity:1; transform:none}
+}
 
 /* Секция видима, если открыта по якорю */
 .section:target{opacity:1 !important; transform:none !important}


### PR DESCRIPTION
## Summary
- make sections visible by default and gate fade-in animation behind prefers-reduced-motion
- keep anchor targets visible so the "Наши результаты" block is accessible on mobile browsers

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da0c6f816c832ea6b6c92225e21c67